### PR TITLE
use fully qualified column name in unions

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -58,8 +58,7 @@
 
                     {%- set col = column_superset[col_name] %}
                     {%- set col_type = column_override.get(col.column, col.data_type) %}
-                    {%- set col_name = adapter.quote(col_name) if col_name in table_columns[table] else 'null' %}
-                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif %}
+                    {%- set col_name = adapter.quote(table.name) + '.' + adapter.quote(col_name) if col_name in table_columns[table] else 'null' %}                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif %}
                 {%- endfor %}
 
             from {{ table }}


### PR DESCRIPTION
better support for an edge case in Bigquery, which gets confused by casting a column with the same name as its parent table. Fixes #173